### PR TITLE
Added support for additional controllers, not only the main one

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -18,21 +18,21 @@
 * Authored by: Kris Henriksen <krishenriksen.work@gmail.com>
 #
 * AnberPorts-Keyboard-Mouse
-* 
+*
 * Part of the code is from from https://github.com/krishenriksen/AnberPorts/blob/master/AnberPorts-Keyboard-Mouse/main.c (mostly the fake keyboard)
 * Fake Xbox code from: https://github.com/Emanem/js2xbox
-* 
+*
 * Modified (badly) by: Shanti Gilbert for EmuELEC
 * Modified further by: Nikolai Wuttke for EmuELEC (Added support for SDL and the SDLGameControllerdb.txt)
 * Modified further by: Jacob Smith
-* 
-* Any help improving this code would be greatly appreciated! 
-* 
+*
+* Any help improving this code would be greatly appreciated!
+*
 * DONE: Xbox360 mode: Fix triggers so that they report from 0 to 255 like real Xbox triggers
 *       Xbox360 mode: Figure out why the axis are not correctly labeled?  SDL_CONTROLLER_AXIS_RIGHTX / SDL_CONTROLLER_AXIS_RIGHTY / SDL_CONTROLLER_AXIS_TRIGGERLEFT / SDL_CONTROLLER_AXIS_TRIGGERRIGHT
 *       Keyboard mode: Add a config file option to load mappings from.
 *       add L2/R2 triggers
-* 
+*
 */
 
 #include "gptokeyb.h"
@@ -66,18 +66,7 @@ bool handleInputEvent(const SDL_Event& event)
         break;
 
     case SDL_CONTROLLERDEVICEADDED:
-        if (xbox360_mode == true || config_mode == true) {
-            SDL_GameControllerOpen(0);
-
-            // SDL_GameController* controller = SDL_GameControllerOpen(0);
-            // if (controller) {
-            //     const char *name = SDL_GameControllerNameForIndex(0);
-            //     printf("Joystick %i has game controller name '%s'\n", 0, name);
-            // }
-
-        } else {
-            SDL_GameControllerOpen(event.cdevice.which);
-        }
+        SDL_GameControllerOpen(event.cdevice.which);
         break;
 
     case SDL_CONTROLLERDEVICEREMOVED:


### PR DESCRIPTION
I have an issue on JELOS that I can control Undertale port only with main console internal controls. I discovered that this is because there is hardcoded index `0` to use the most-first controller in the system. I fixed it and now it listens for all connected controllers and I can control game with additional external controller as well as with internal controller.