### PR TITLE
Add verbose logging arg and prepend log statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ gptokeyb provides a kill switch for an application and mapping of gamepad button
 
 `-sudokill` indicates that `sudo kill -9 <application name>` will be used to close the application instead of `killall <application name>`
 
+` -v` enables verbose log output which provides more details in logfiles
+
 ### Keyboard Mapping Options
 The config file that specifies button mapping for keyboard and mouse functions takes the form of `%s = %s` which is `gamepad button` = `keyboard key`. Any comment lines beginning with `#` are ignored. Deadzone values are used for analog sticks and triggers, and may be device specific. `mouse_scale` affects the speed of mouse movement, with a larger value causing slower movement. `mouse_scale = 8192` generally works well for RK3326 devices. `gamepad button = \"` can be used to unassign a button.
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -44,7 +44,7 @@ std::vector<config_option> parseConfigFile(const char* path)
     FILE* fp;
 
     if ((fp = fopen(path, "r+")) == NULL) {
-        fprintf(stderr, "fopen(%s):", path);
+        fprintf(stderr, "[GPTK]: fopen(%s):", path);
         perror("");
         return result;
     }

--- a/src/gptokeyb.cpp
+++ b/src/gptokeyb.cpp
@@ -191,7 +191,7 @@ int main(int argc, char* argv[])
             textinputinteractive_mode = true;
             state.textinputinteractive_mode_active = false;
         } else if (strcmp(argv[ii], "-x11") == 0) {
-            fprintf(stderr, "ENABLE X11\n");
+            fprintf(stderr, "[GPTK]: ENABLE X11\n");
 #ifdef ENABLE_X11
             output_mode = OM_X11;
 #endif
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
             }
             
         } else if (( strcmp(argv[ii], "-v") == 0)) {
-                printf("Verbose logging enabled\n");
+                printf("[GPTK]: Verbose logging enabled\n");
                 verbose = true;
         }
     }
@@ -251,7 +251,7 @@ int main(int argc, char* argv[])
 
     // SDL initialization and main loop
     if (SDL_Init(SDL_INIT_GAMECONTROLLER | SDL_INIT_TIMER) != 0) {
-        printf("SDL_Init() failed: %s\n", SDL_GetError());
+        printf("[GPTK]: SDL_Init() failed: %s\n", SDL_GetError());
         return -1;
     }
 
@@ -264,16 +264,16 @@ int main(int argc, char* argv[])
 
         // if we are in config mode, read the file
         if (config_mode) {
-            printf("Using ConfigFile %s\n", config_file);
+            printf("[GPTK]: Using ConfigFile %s\n", config_file);
             readConfigFile(config_file);
         }
 
         // if we are in textinput mode, note the text preset
         if (textinputpreset_mode) {
             if (config.text_input_preset != NULL) {
-                printf("text input preset is %s\n", config.text_input_preset);
+                printf("[GPTK]: text input preset is %s\n", config.text_input_preset);
             } else {
-                printf("text input preset is not set\n");
+                printf("[GPTK]: text input preset is not set\n");
                 //textinputpreset_mode = false;   removed so that Enter key can be pressed
             }
         } 
@@ -281,13 +281,13 @@ int main(int argc, char* argv[])
         // if we are in textinputinteractive mode, initialise the character set
         if (textinputinteractive_mode) {
             initialiseCharacterSet();
-            printf("interactive text input mode available\n");
+            printf("[GPTK]: interactive text input mode available\n");
             if (textinputinteractive_noautocapitals)
-                printf("interactive text input mode without auto-capitals\n");
+                printf("[GPTK]: interactive text input mode without auto-capitals\n");
             if (textinputinteractive_extrasymbols)
-                printf("interactive text input mode includes extra symbols\n");
+                printf("[GPTK]: interactive text input mode includes extra symbols\n");
             if (textinputinteractive_numbersonly)
-                printf("interactive text input mode with numbers only\n");
+                printf("[GPTK]: interactive text input mode with numbers only\n");
         }
     }
 
@@ -325,7 +325,7 @@ int main(int argc, char* argv[])
             SDL_Delay(config.fake_mouse_delay);
         } else {
             if (!SDL_WaitEvent(&event)) {
-                printf("SDL_WaitEvent() failed: %s\n", SDL_GetError());
+                printf("[GPTK]: SDL_WaitEvent() failed: %s\n", SDL_GetError());
                 shutdownFakeKeyboardMouseDevice();
                 return -1;
             }

--- a/src/gptokeyb.cpp
+++ b/src/gptokeyb.cpp
@@ -45,6 +45,7 @@ bool sudo_kill = false; //allow sudo kill instead of killall for non-emuelec sys
 bool pckill_mode = false; //emit alt+f4 to close apps on pc during kill mode, if env variable is set
 bool openbor_mode = false;
 bool xbox360_mode = false;
+bool verbose = false;
 bool textinputpreset_mode = false; 
 bool textinputinteractive_mode = false;
 bool textinputinteractive_noautocapitals = false;
@@ -222,7 +223,10 @@ int main(int argc, char* argv[])
                 }
             }
             
-        } 
+        } else if (( strcmp(argv[ii], "-v") == 0)) {
+                printf("Verbose logging enabled\n");
+                verbose = true;
+        }
     }
 
     // Add textinput_interactive mode, check for extra options via environment variable if available

--- a/src/gptokeyb.h
+++ b/src/gptokeyb.h
@@ -130,6 +130,7 @@ void setKeyRepeat(int code, bool is_pressed);
 void processKeys();
 
 extern int uinp_fd;
+extern bool verbose;
 extern uinput_user_dev uidev;
 
 extern GptokeybConfig config;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -45,8 +45,9 @@ bool handleInputEvent(const SDL_Event& event)
     case SDL_CONTROLLERBUTTONUP:
         {
             const bool is_pressed = event.type == SDL_CONTROLLERBUTTONDOWN;
-
-            fprintf(stderr, "SDL_BTN_%s: %d\n", (is_pressed ? "DOWN" : "UP"), event.cbutton.button);
+            if (verbose) {
+                fprintf(stderr, "SDL_BTN_%s: %d\n", (is_pressed ? "DOWN" : "UP"), event.cbutton.button);
+            }
 
             if (state.textinputinteractive_mode_active) {
                 handleEventBtnInteractiveKeyboard(event, is_pressed);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -46,7 +46,7 @@ bool handleInputEvent(const SDL_Event& event)
         {
             const bool is_pressed = event.type == SDL_CONTROLLERBUTTONDOWN;
             if (verbose) {
-                fprintf(stderr, "SDL_BTN_%s: %d\n", (is_pressed ? "DOWN" : "UP"), event.cbutton.button);
+                fprintf(stderr, "[GPTK]: SDL_BTN_%s: %d\n", (is_pressed ? "DOWN" : "UP"), event.cbutton.button);
             }
 
             if (state.textinputinteractive_mode_active) {
@@ -74,7 +74,7 @@ bool handleInputEvent(const SDL_Event& event)
             SDL_GameController* controller = SDL_GameControllerOpen(event.cdevice.which);
             if (controller) {
                 const char *name = SDL_GameControllerNameForIndex(event.cdevice.which);
-                printf("Joystick %i has game controller name '%s'\n", event.cdevice.which, name);
+                printf("[GPTK]: Joystick %i has game controller name '%s'\n", event.cdevice.which, name);
             }
 
         } else {

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -419,7 +419,7 @@ void handleEventBtnInteractiveKeyboard(const SDL_Event &event, bool is_pressed)
             } else { // reached limit of characters
                 confirmTextInputCharacter();
                 state.textinputinteractive_mode_active = false;
-                printf("text input interactive mode no longer active\n");
+                printf("[GPTK]: text input interactive mode no longer active\n");
             }
         }
         break; //SDL_CONTROLLER_BUTTON_DPAD_RIGHT
@@ -465,7 +465,7 @@ void handleEventBtnInteractiveKeyboard(const SDL_Event &event, bool is_pressed)
             confirmTextInputCharacter();
             //disable interactive mode
             state.textinputinteractive_mode_active = false;
-            printf("text input interactive mode no longer active\n");
+            printf("[GPTK]: text input interactive mode no longer active\n");
         }
         break; //SDL_CONTROLLER_BUTTON_A
 
@@ -480,7 +480,7 @@ void handleEventBtnInteractiveKeyboard(const SDL_Event &event, bool is_pressed)
             }
             initialiseCharacters(); //reset the character selections ready for new text to be added later
             state.textinputinteractive_mode_active = false;
-            printf("text input interactive mode no longer active\n");
+            printf("[GPTK]: text input interactive mode no longer active\n");
         }
         break; //SDL_CONTROLLER_BUTTON_BACK
 
@@ -489,7 +489,7 @@ void handleEventBtnInteractiveKeyboard(const SDL_Event &event, bool is_pressed)
             confirmTextInputCharacter(); // send ENTER key to confirm text entry
             //disable interactive mode
             state.textinputinteractive_mode_active = false;
-            printf("text input interactive mode no longer active\n");
+            printf("[GPTK]: text input interactive mode no longer active\n");
         }
         break; //SDL_CONTROLLER_BUTTON_START
 
@@ -740,11 +740,11 @@ void handleEventBtnFakeKeyboardMouseDevice(const SDL_Event& event, bool is_press
         doKillMode();
     } //kill mode 
     else if ((textinputpreset_mode) && (state.textinputpresettrigger_pressed && state.start_pressed)) { //activate input preset mode - send predefined text as a series of keystrokes
-        printf("text input preset pressed\n");
+        printf("[GPTK]: text input preset pressed\n");
         state.start_combo_triggered = true;
         if (state.start_jsdevice == state.textinputpresettrigger_jsdevice) {
             if (config.text_input_preset != NULL) {
-                printf("text input processing %s\n", config.text_input_preset);
+                printf("[GPTK]: text input processing %s\n", config.text_input_preset);
                 processKeys();
             }
         }
@@ -754,10 +754,10 @@ void handleEventBtnFakeKeyboardMouseDevice(const SDL_Event& event, bool is_press
         state.textinputpresettrigger_jsdevice = 0;
     } //input preset trigger mode (i.e. not kill mode)
     else if ((textinputpreset_mode) && (state.textinputconfirmtrigger_pressed && state.start_pressed)) { //activate input preset confirm mode - send ENTER key
-        printf("text input confirm pressed\n");
+        printf("[GPTK]: text input confirm pressed\n");
         state.start_combo_triggered = true;
         if (state.start_jsdevice == state.textinputconfirmtrigger_jsdevice) {
-            printf("text input Enter key\n");
+            printf("[GPTK]: text input Enter key\n");
             emitKey(char_to_keycode("enter"), true);
             SDL_Delay(15);
             emitKey(char_to_keycode("enter"), false);
@@ -768,10 +768,10 @@ void handleEventBtnFakeKeyboardMouseDevice(const SDL_Event& event, bool is_press
         state.textinputconfirmtrigger_jsdevice = 0;
     } //input confirm trigger mode (i.e. not kill mode)         
     else if ((textinputinteractive_mode) && (state.textinputinteractivetrigger_pressed && state.start_pressed)) { //activate interactive text input mode
-        printf("text input interactive pressed\n");
+        printf("[GPTK]: text input interactive pressed\n");
         state.start_combo_triggered = true;
         if (state.start_jsdevice == state.textinputinteractivetrigger_jsdevice) {
-            printf("text input interactive mode active\n");
+            printf("[GPTK]: text input interactive mode active\n");
             state.textinputinteractive_mode_active = true;
             SDL_RemoveTimer( state.key_repeat_timer_id ); // disable any active key repeat timer
             current_character = 0;

--- a/src/output_uinput.cpp
+++ b/src/output_uinput.cpp
@@ -42,12 +42,12 @@ uinput_user_dev uidev;
 
 int emit_init_uinput()
 {
-    fprintf(stderr, "Running in UINPUT output mode.\n");
+    fprintf(stderr, "[GPTK]: Running in UINPUT output mode.\n");
     int success = 0;
 
     uinp_fd = open("/dev/uinput", O_WRONLY | O_NONBLOCK);
     if (uinp_fd < 0) {
-        fprintf(stderr, "Unable to open /dev/uinput\n");
+        fprintf(stderr, "[GPTK]: Unable to open /dev/uinput\n");
         return -1;
     }
 
@@ -57,7 +57,7 @@ int emit_init_uinput()
     uidev.id.bustype = BUS_USB;
 
     if (xbox360_mode) {
-        printf("Running in Fake Xbox 360 Mode\n");
+        printf("[GPTK]: Running in Fake Xbox 360 Mode\n");
         success = setupFakeXbox360Device(uidev, uinp_fd);
 
         if (success < 0)
@@ -66,7 +66,7 @@ int emit_init_uinput()
             return success;
         }
     } else {
-        printf("Running in Fake Keyboard mode\n");
+        printf("[GPTK]: Running in Fake Keyboard mode\n");
         success = setupFakeKeyboardMouseDevice(uidev, uinp_fd);
 
         if (success < 0)
@@ -80,7 +80,7 @@ int emit_init_uinput()
     write(uinp_fd, &uidev, sizeof(uidev));
 
     if (ioctl(uinp_fd, UI_DEV_CREATE)) {
-        fprintf(stderr, "Unable to create UINPUT device.");
+        fprintf(stderr, "[GPTK]: Unable to create UINPUT device.");
         shutdownFakeKeyboardMouseDevice();
         uinp_fd = -1;
         return -1;

--- a/src/output_x11.cpp
+++ b/src/output_x11.cpp
@@ -167,7 +167,7 @@ static inline int keysm_to_x11keysym(int keysym)
 
 int emit_init_x11()
 {
-    fprintf(stderr, "Running in X11 output mode.\n");
+    fprintf(stderr, "[GPTK]: Running in X11 output mode.\n");
     Display *display = XOpenDisplay(NULL);
 
     if (xbox360_mode)
@@ -175,7 +175,7 @@ int emit_init_x11()
 
     if (display == NULL)
     {
-        fprintf(stderr, "Cannot open display\n");
+        fprintf(stderr, "[GPTK]: Cannot open display\n");
         return -1;
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -401,25 +401,25 @@ void doKillMode()
     SDL_RemoveTimer( state.key_repeat_timer_id );
     if (state.start_jsdevice == state.hotkey_jsdevice) {
         if (! sudo_kill) {
-            printf("Killing: %s\n", AppToKill);
+            printf("[GPTK]: Killing: %s\n", AppToKill);
             system(("pkill -f '" + std::string(AppToKill) + "' ").c_str());
             // system("show_splash.sh exit");
 
             sleep(3);
             if (system((" pgrep '" + std::string(AppToKill) + "' ").c_str()) == 0) {
-                printf("Forcefully Killing: %s\n", AppToKill);
+                printf("[GPTK]: Forcefully Killing: %s\n", AppToKill);
                 system((" pkill -9 -f '" + std::string(AppToKill) + "' ").c_str());
             }
 
             exit(0); 
         } else {
-            printf("Killing: %s\n", AppToKill);
+            printf("[GPTK]: Killing: %s\n", AppToKill);
             system((" sudo pkill -f '" + std::string(AppToKill) + "' ").c_str());
 
             sleep(3);
 
             if (system((" pgrep '" + std::string(AppToKill) + "' ").c_str()) == 0) {
-                printf("Forcefully Killing: %s\n", AppToKill);
+                printf("[GPTK]: Forcefully Killing: %s\n", AppToKill);
                 system((" sudo pkill -9 -f '" + std::string(AppToKill) + "' ").c_str());
             }
 

--- a/src/xbox360.cpp
+++ b/src/xbox360.cpp
@@ -79,7 +79,7 @@ int setupFakeXbox360Device(uinput_user_dev& device, int fd)
             ioctl(fd, UI_SET_ABSBIT, ABS_RZ) ||
             ioctl(fd, UI_SET_ABSBIT, ABS_HAT0X) ||
             ioctl(fd, UI_SET_ABSBIT, ABS_HAT0Y)) {
-        fprintf(stderr, "Failed to configure fake Xbox 360 controller\n");
+        fprintf(stderr, "[GPTK]: Failed to configure fake Xbox 360 controller\n");
         return -1;
     }
 


### PR DESCRIPTION
- Add `-v` commandline argument to enable verbose logging and prevent logfile pollution.
- Prepend `printf` statements with `[GPTK]:` for added visibility and clarity when mixed with other software sharing the same logfile