### PR TITLE
Reject our own fake xbox controller to prevent loop

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -73,8 +73,14 @@ bool handleInputEvent(const SDL_Event& event)
 
             SDL_GameController* controller = SDL_GameControllerOpen(event.cdevice.which);
             if (controller) {
-                const char *name = SDL_GameControllerNameForIndex(event.cdevice.which);
-                printf("[GPTK]: Joystick %i has game controller name '%s'\n", event.cdevice.which, name);
+                SDL_Joystick *joystick = SDL_GameControllerGetJoystick(controller);
+                const char *name = SDL_JoystickName(joystick); //Joystick name is the actual device name, not the name given to the device in gamecontrollerdb.txt
+                printf("[GPTK]: Joystick %i has device name '%s'\n", event.cdevice.which, name);
+                // Reject our own fake xbox360 controller to prevent creating a loop of input events
+                if (xbox360_mode && strcmp(name, "Microsoft X-Box 360 pad") == 0)
+                {
+                    SDL_GameControllerClose(controller);
+                }
             }
 
         } else {


### PR DESCRIPTION
This is pretty much the same as the name filter on this gptk2 PR https://github.com/PortsMaster/gptokeyb2/pull/7
The jist is that the SDL2 that gptk uses to read input picks up the events from the fake xbox controller gptk emits. This creates an endless loop of events being passed through gptk, causing very high CPU usage and broken inputs on the game.