### PR TITLE
Use pgrep -f for long proc names

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -406,7 +406,7 @@ void doKillMode()
             // system("show_splash.sh exit");
 
             sleep(3);
-            if (system((" pgrep '" + std::string(AppToKill) + "' ").c_str()) == 0) {
+            if (system((" pgrep -f '" + std::string(AppToKill) + "' ").c_str()) == 0) {
                 printf("[GPTK]: Forcefully Killing: %s\n", AppToKill);
                 system((" pkill -9 -f '" + std::string(AppToKill) + "' ").c_str());
             }
@@ -418,7 +418,7 @@ void doKillMode()
 
             sleep(3);
 
-            if (system((" pgrep '" + std::string(AppToKill) + "' ").c_str()) == 0) {
+            if (system((" pgrep -f '" + std::string(AppToKill) + "' ").c_str()) == 0) {
                 printf("[GPTK]: Forcefully Killing: %s\n", AppToKill);
                 system((" sudo pkill -9 -f '" + std::string(AppToKill) + "' ").c_str());
             }


### PR DESCRIPTION
Prevent truncating the proc name if longer than 15 characters.