### PR TITLE
Fix Inverted D-pad on Some Unity Games by Specifying Xbox 360 Gamepad Version.

### DIFF
--- a/src/xbox360.cpp
+++ b/src/xbox360.cpp
@@ -56,8 +56,9 @@ void UINPUT_SET_ABS_P(
 int setupFakeXbox360Device(uinput_user_dev& device, int fd)
 {
     strncpy(device.name, "Microsoft X-Box 360 pad", UINPUT_MAX_NAME_SIZE);
-    device.id.vendor = 0x045e;  /* sample vendor */
-    device.id.product = 0x028e; /* sample product */
+    device.id.vendor = 0x045e;  /* Microsoft */
+    device.id.product = 0x028e; /* X-Box 360 */
+    device.id.version = 0x0104; /* Revision with proper dpad direction */
 
     if (
             ioctl(fd, UI_SET_EVBIT, EV_KEY) || ioctl(fd, UI_SET_EVBIT, EV_SYN) ||


### PR DESCRIPTION
Fixes Inverted D-pad on some Unity Games. See here for more discussion:

https://github.com/ROCKNIX/rocknix-hotkey/pull/2

Apparently, the first Xbox 360 Gamepad was buggy, and some Unity games attempt to compensate when they don't need to, resulting in inverted D-pad. This fixes that by specifying the fixed Xbox 360 Gamepad version.

Thanks! :D